### PR TITLE
JB Create New Department - Ticket#6

### DIFF
--- a/workforce/templates/workforce/addDepartment.html
+++ b/workforce/templates/workforce/addDepartment.html
@@ -1,0 +1,11 @@
+<h1>Add a Department </h1>
+
+<form action="{% url 'workforce:addDepartment' %}" method='POST'>
+    {% csrf_token %}
+    <label for="dept_name">Department Name</label>
+    <input type="text" name="department_name" id="dept_name">
+    <label for="dept_budget">Department Budget</label>
+    <input type="text" name="department_budget" id="dept_budget">
+
+    <input type="submit" value="Save Department">
+</form>

--- a/workforce/templates/workforce/departmentList.html
+++ b/workforce/templates/workforce/departmentList.html
@@ -11,4 +11,5 @@
 {% else %}
     <p>No departments Available.</p>
 {% endif %}
+<a href="{% url 'workforce:departmentForm' %}"><button type="button">Add New Department</button></a>
 

--- a/workforce/tests/test_department.py
+++ b/workforce/tests/test_department.py
@@ -50,14 +50,11 @@ class DepartmentTest(TestCase):
 
     def test_add_department(self):
 
-        response = self.client.post(reverse('workforce:'))
-#         Your test suite must verify that the content of the response has the required input fields.
-# Your test suite must verify that when a POST operation is performed to the corresponding URL, then a successful response is received (i.e. status code must be 200)
+        post_response = self.client.post(reverse('workforce:addDepartment'), {'department_name': 'Finance', 'department_budget': 2000})
 
+        self.assertEqual(post_response.status_code, 302)
 
-    # def test_post_artist(self):
+        form_response = self.client.get(reverse('workforce:departmentForm'))
+        form_content = '<label for="dept_name">Department Name</label>\n    <input type="text" name="department_name" id="dept_name">\n    <label for="dept_budget">Department Budget</label>\n    <input type="text" name="department_budget" id="dept_budget">\n\n    <input type="submit" value="Save Department">'
 
-    #   response = self.client.post(reverse('history:artist_form'), {'name': 'Bill Board', 'birth_date': '10/31/67', 'biggest_hit': "So Blue Fer You"})
-
-    #   # Getting 302 back because we have a success url and the view is redirecting
-    #   self.assertEqual(response.status_code, 302)
+        self.assertIn(form_content.encode(), form_response.content)

--- a/workforce/tests/test_employee.py
+++ b/workforce/tests/test_employee.py
@@ -45,34 +45,34 @@ class EmployeeTest(TestCase):
         self.assertIn(new_employee.department.name.encode(), response.content)
         self.assertEqual(response.context["training_programs"][0].trainingProgram.name, new_training.name)
 
-        def test_list_employee(self):
-            """
+    def test_list_employee(self):
+        """
 
-            adds new employee and department to temp database and confirms accurate response
-            code, addition of employee to table and confirms that accurate first name, last name and
-            department are being returned
+        adds new employee and department to temp database and confirms accurate response
+        code, addition of employee to table and confirms that accurate first name, last name and
+        department are being returned
 
-            """
-            new_employee = Employee.objects.create(
-                firstName="Richard",
-                lastName="Lancaster",
-                startDate="1998-08-17",
-                isSupervisor="1",
-                department_id="1"
-            )
+        """
+        new_employee = Employee.objects.create(
+            firstName="Richard",
+            lastName="Lancaster",
+            startDate="1998-08-17",
+            isSupervisor="1",
+            department_id="1"
+        )
 
-            new_department = Department.objects.create(
-                name="Accounting",
-                budget=100000
-            )
+        new_department = Department.objects.create(
+            name="Accounting",
+            budget=100000
+        )
 
-            response = self.client.get(reverse('workforce:employeeList'))
+        response = self.client.get(reverse('workforce:employeeList'))
 
-            self.assertEqual(response.status_code, 200)  # Check that the response is 200 OK.
-            self.assertEqual(len(response.context['all_employees']), 1)
-            self.assertIn(new_employee.firstName.encode(), response.content)
-            self.assertIn(new_employee.lastName.encode(), response.content)
-            self.assertIn(new_department.name.encode(), response.content)
+        self.assertEqual(response.status_code, 200)  # Check that the response is 200 OK.
+        self.assertEqual(len(response.context['all_employees']), 1)
+        self.assertIn(new_employee.firstName.encode(), response.content)
+        self.assertIn(new_employee.lastName.encode(), response.content)
+        self.assertIn(new_department.name.encode(), response.content)
 
     # def test_get_artist_form(self):
 

--- a/workforce/tests/test_trainingProgram.py
+++ b/workforce/tests/test_trainingProgram.py
@@ -22,15 +22,15 @@ class TrainingTest(TestCase):
 
         # if this breaks checks print out your response.content to see if it has changed and adjust test_me to match
         test_me = b'\n<h2>View Upcoming Training Programs</h2>\n\n<ul>\n    \n    <li>\n        <a href="/workforce/programs/1/">\n            Coding with dummy code\n        </a>\n    </li>\n    \n</ul>\n\n<a href="/workforce/addtraining">Create New Training Program</a>\n</br>\n<a href="/workforce/pastprograms">View Past Training Programs</a>'
-        
+
         self.assertIn(test_me, response.content)
 
     def test_get_program_form(self):
         response = self.client.get(reverse('workforce:addTraining'))
-        
+
         # if this breaks checks print out your response.content to see if it has changed and adjust test_form to match
         test_form = '<label>Event Name:\n        <input type="text" name="trainName" />\n    </label>\n    <label>Event Start Date:\n        <input type="date" name="trainStart" />\n    </label>\n    <label>Event End Date:\n        <input type="date" name="trainEnd" />\n    </label>\n    <label> Max Attendees:\n        <input type="int" name="trainMax" />\n    </label>\n    <input type="submit" value="SAVE" />\n</form>'.encode()
-        
+
         self.assertIn(test_form, response.content)
 
 

--- a/workforce/urls.py
+++ b/workforce/urls.py
@@ -16,7 +16,9 @@ urlpatterns = [
     path('departmentDetail/<int:department_id>/', views.detail, name='departmentDetail'),
     path('employees/<int:employee_id>/', views.employeeDetail, name='employeeDetail'),
     path('training/', views.trainingList, name='training'),
-    path('addtraining/', views.newTraining, name='addTraining')
+    path('addtraining/', views.newTraining, name='addTraining'),
+    path('departmentForm/', views.departmentForm, name='departmentForm'),
+    path('addDepartment/', views.addDepartment, name='addDepartment'),
 ]
 
 # example from DjangoMusic Exercise

--- a/workforce/views/__init__.py
+++ b/workforce/views/__init__.py
@@ -3,3 +3,4 @@ from .employeeDetail_view import employeeDetail
 from .departmentList_view import departmentList
 from .trainingProgram_views import trainingList, newTraining
 from .employeeList_view import employeeList
+from .addDepartment_view import addDepartment, departmentForm

--- a/workforce/views/addDepartment_view.py
+++ b/workforce/views/addDepartment_view.py
@@ -1,0 +1,20 @@
+from django.shortcuts import render, get_object_or_404
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+from ..models import Department, Employee, TrainingProgram
+
+def departmentForm(request):
+    return render(request, 'workforce/addDepartment.html')
+
+def addDepartment(request):
+
+    department_name = request.POST["department_name"]
+    department_budget = request.POST["department_budget"]
+
+    new_department = Department.objects.create(
+        name = department_name,
+        budget = department_budget
+    )
+
+    return HttpResponseRedirect(reverse('workforce:departmentList'))


### PR DESCRIPTION
### **Description:**
Added the ability to create a new department from the department list page. Clicking on the "Add New Department" button takes the user to the new department form. After submitting the form the user is redirected back to the department list page.

### **Steps to Test:**

Checkout to branch jb-create-dept

Enter the url http://localhost:8000/workforce/departments/ into your browser.

A list of all the departments will be rendered in the browser as well as a Create New Department button.

Once the link is clicked you will be taken to a form where you are given inputs to enter a department name and a department budget.

Once a user submits the form they will be redirected to the list of all departments and will see the new department at the bottom of the list.

Link to Feature Ticket:
[Ticket 6](https://github.com/blathering-barnacles/Bangazon/issues/6#issue-403244796)